### PR TITLE
Fix: data preprocessing in inference produces passages list that doesn't match queries list

### DIFF
--- a/scripts/CRAG_Inference.py
+++ b/scripts/CRAG_Inference.py
@@ -94,7 +94,7 @@ def data_preprocess(file):
                         tmp_psgs = [p]
                     else:
                         tmp_psgs.append(p)
-                passages.append(' [sep] '.join(tmp_psgs))
+            passages.append(' [sep] '.join(tmp_psgs))
         else:
             for line in f.readlines():
                 c = line.strip()
@@ -109,7 +109,7 @@ def data_preprocess(file):
                         tmp_psgs = [p]
                     else:
                         tmp_psgs.append(p)
-                passages.append(' [sep] '.join(tmp_psgs))
+            passages.append(' [sep] '.join(tmp_psgs))
     return queries, passages
 
 def get_evaluator_data(file):


### PR DESCRIPTION
The function `data_preprocess(file)` in CRAG_Inference should produce an passages array of same length of queries array. However while testing with the Popqa dataset, I realized that the passages array is much longer than the queries array.

The reason is a wrong indentation. `tmp_psgs`  is appended to `passages` after every line in the preprocessed file. However, `tmp_psgs` should only be appended if the query is different from last line's query or at the end of looping through the lines. A different indentation fixes the bug to the intended behavior. 