### PR TITLE
Fix: data preprocessing in inference fails with provided test_popqa.txt

### DIFF
--- a/scripts/CRAG_Inference.py
+++ b/scripts/CRAG_Inference.py
@@ -83,7 +83,10 @@ def data_preprocess(file):
         if with_label:
             for line in f.readlines()[:]:
                 c, l = line.strip().split("\t")
-                q, p = c.split(' [SEP] ')
+                try:
+                    q, p = c.split(' [SEP] ')
+                except ValueError:
+                    continue # Skip line if no passage in line
                 if queries == []:
                     queries.append(q)
                     tmp_psgs = [p]
@@ -98,7 +101,10 @@ def data_preprocess(file):
         else:
             for line in f.readlines():
                 c = line.strip()
-                q, p = c.split(' [SEP] ')
+                try:
+                    q, p = c.split(' [SEP] ')
+                except ValueError:
+                    continue # Skip line if no passage in line
                 if queries == []:
                     queries.append(q)
                     tmp_psgs = [p]


### PR DESCRIPTION
The function `data_preprocess(file)` fails to process the `test_popqa.txt`. The function tries to split every line of the processed file into two elements by '  [SEP]  '. However, not every line contains '  [SEP]  '. So, the function raises ValueErrors. 

Some lines only contain a query but no passage, e. g. `What is Henry Feilden's occupation? [SEP]`. In consequence, this line can't be split by '  [SEP]  ' since it only includes '  [SEP] ' (without a trailing space) .

I propose to catch the value error and skip the lines in question.